### PR TITLE
[WEB-8872] Use an active "from" email address in the `Sign in detected, was it you?` email

### DIFF
--- a/src/spec/email_config.json
+++ b/src/spec/email_config.json
@@ -1485,6 +1485,12 @@
   },
   "login-notification": {
     "description": "Email template for a user login with login client, time, and location information.",
+    "email_from": {
+      "from": {
+        "email": "support@serato.com",
+        "name": "Serato"
+      }
+    },
     "languages": {
       "en": {
         "template_id": "d-5e9a88a28e2d4d338e977cf56f5dc48b",


### PR DESCRIPTION
Add `email_from` to the login notification config, which sets the from email when the login email is sent to the user