### PR TITLE
[WEB-9296] Producer DJ "thanks for subscribing" SendGrid email missing details (Production)

### DIFF
--- a/src/spec/email_config.json
+++ b/src/spec/email_config.json
@@ -1281,7 +1281,11 @@
         "categories": ["English"]
       }
     },
-    "template_params": [],
+    "template_params": [
+      "plan_name",
+      "billing_start_date",
+      "billing_period"
+    ],
     "categories": ["st-dj-sub"]
   },
   "subscription-plan-change-immediate": {


### PR DESCRIPTION
Cause:
Template wasn't being passed the params

Fix:
Pass the params and validate them